### PR TITLE
Clean up local rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,32 +1,3 @@
-inherit_from: .rubocop_todo.yml
-
-AllCops:
-  TargetRubyVersion: 2.6
-  Exclude:
-    - 'db/schema.rb'
-    - 'vendor/**/*'
-    - 'bin/**/*'
-    - 'node_modules/**/*'
-
-Naming/VariableNumber:
-  EnforcedStyle: snake_case
-
-Metrics/MethodLength:
-  Exclude:
-    - 'db/**/*'
-
-Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
-
-Style/Documentation:
-  Exclude:
-    - 'db/**/*'
-
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
+inherit_from:
+  - .rubocop_todo.yml
+  - ihv-rubocop.yml


### PR DESCRIPTION
We had the rules copied in both files so this change uses `ihv-rubocop` as the source-of-truth